### PR TITLE
Correct P4Merge link in "External Merge and Diff Tools"

### DIFF
--- a/book/08-customizing-git/sections/config.asc
+++ b/book/08-customizing-git/sections/config.asc
@@ -240,7 +240,7 @@ We'll demonstrate setting up the Perforce Visual Merge Tool (P4Merge) to do your
 If you want to try this out, P4Merge works on all major platforms, so you should be able to do so.
 We'll use path names in the examples that work on Mac and Linux systems; for Windows, you'll have to change `/usr/local/bin` to an executable path in your environment.
 
-To begin, download P4Merge from http://www.perforce.com/downloads/Perforce/[].
+To begin, https://www.perforce.com/product/components/perforce-visual-merge-and-diff-tools[download P4Merge from Perforce].
 Next, you'll set up external wrapper scripts to run your commands.
 We'll use the Mac path for the executable; in other systems, it will be where your `p4merge` binary is installed.
 Set up a merge wrapper script named `extMerge` that calls your binary with all the arguments provided:


### PR DESCRIPTION
The current link is 404. I also changed the wording slightly to indicate the semantics of the link, but I'm happy to correct if there are objections.
